### PR TITLE
api.js arguments can be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The following are **Optional** arguments.
 
 **RECAPTCHA_TABINDEX**: Int - Tabindex of the widget can be used, if the page uses tabidex, to make navigation easier. Defaults to 0
 
+**RECAPTCHA_SCRIPT_ARGS**: String - Arguments to be passed to www.google.com/recaptcha/api.js . Defaults to empty string. 
+
     RECAPTCHA_ENABLED = True
     RECAPTCHA_SITE_KEY = ""
     RECAPTCHA_SECRET_KEY = ""
@@ -110,7 +112,7 @@ The following are **Optional** arguments.
     RECAPTCHA_TYPE = "image"
     RECAPTCHA_SIZE = "compact"
     RECAPTCHA_RTABINDEX = 10
-
+    RECAPTCHA_SCRIPT_ARGS = "onload=onloadCallback"
 ---
 
 (c) 2015 Mardix

--- a/flask_recaptcha.py
+++ b/flask_recaptcha.py
@@ -23,6 +23,7 @@ class DEFAULTS(object):
     TYPE = "image"
     SIZE = "normal"
     TABINDEX = 0
+    SCRIPT_ARGS = ""
 
 
 class ReCaptcha(object):
@@ -41,6 +42,7 @@ class ReCaptcha(object):
             self.type = kwargs.get('type', DEFAULTS.TYPE)
             self.size = kwargs.get('size', DEFAULTS.SIZE)
             self.tabindex = kwargs.get('tabindex', DEFAULTS.TABINDEX)
+            self.script_args = kwargs.get('script_args', DEFAULTS.TABINDEX)
 
         elif app:
             self.init_app(app=app)
@@ -52,7 +54,8 @@ class ReCaptcha(object):
                       theme=app.config.get("RECAPTCHA_THEME", DEFAULTS.THEME),
                       type=app.config.get("RECAPTCHA_TYPE", DEFAULTS.TYPE),
                       size=app.config.get("RECAPTCHA_SIZE", DEFAULTS.SIZE),
-                      tabindex=app.config.get("RECAPTCHA_TABINDEX", DEFAULTS.TABINDEX))
+                      tabindex=app.config.get("RECAPTCHA_TABINDEX", DEFAULTS.TABINDEX),
+                      script_args=app.config.get("RECAPTCHA_SCRIPT_ARGS", DEFAULTS.SCRIPT_ARGS))
 
         @app.context_processor
         def get_code():
@@ -64,10 +67,10 @@ class ReCaptcha(object):
         :return:
         """
         return "" if not self.is_enabled else ("""
-        <script src='//www.google.com/recaptcha/api.js'></script>
+        <script src='//www.google.com/recaptcha/api.js?{SCRIPT_ARGS}'></script>
         <div class="g-recaptcha" data-sitekey="{SITE_KEY}" data-theme="{THEME}" data-type="{TYPE}" data-size="{SIZE}"\
          data-tabindex="{TABINDEX}"></div>
-        """.format(SITE_KEY=self.site_key, THEME=self.theme, TYPE=self.type, SIZE=self.size, TABINDEX=self.tabindex))
+        """.format(SCRIPT_ARGS=self.script_args, SITE_KEY=self.site_key, THEME=self.theme, TYPE=self.type, SIZE=self.size, TABINDEX=self.tabindex))
 
     def verify(self, response=None, remote_ip=None):
         if self.is_enabled:


### PR DESCRIPTION
Google reCaptcha api allows a set a arguments that can be passed to api.js, such as a callback function to be executed when it loads. This can be added now by setting 

RECAPTCHA_SCRIPT_ARGS = "onload=onloadCallback"