### PR TITLE
[FIX] Markup should be imported from MarkupSafe

### DIFF
--- a/flask_recaptcha.py
+++ b/flask_recaptcha.py
@@ -11,7 +11,10 @@ __copyright__ = "(c) 2015 Mardix"
 
 try:
     from flask import request
-    from markupsafe import Markup
+    try:
+        from jinja2 import Markup
+    except ImportError:
+        from markupsafe import Markup
     import requests
 except ImportError as ex:
     print("Missing dependencies")

--- a/flask_recaptcha.py
+++ b/flask_recaptcha.py
@@ -11,7 +11,7 @@ __copyright__ = "(c) 2015 Mardix"
 
 try:
     from flask import request
-    from jinja2 import Markup
+    from markupsafe import Markup
     import requests
 except ImportError as ex:
     print("Missing dependencies")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "flask",
-        "requests"
+        "requests",
+        "MarkupSafe"
     ],
     keywords=['flask', 'recaptcha', "validate"],
     platforms='any',


### PR DESCRIPTION
Markup is not exist in Jinja since 3.1.0, its now handling by MarkupSafe

see https://jinja.palletsprojects.com/en/3.1.x/changes/